### PR TITLE
Optional usage with `company-mode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Append a list of custom accents to the default collection.
                       (u (ŭ))))
 ```
 
+### `company-mode`
+
+If you have [company-mode](https://github.com/company-mode/company-mode) installed, you can use `accent-company` instead of `accent-menu`. It probably doesn't make much sense to add it to `company-backends`, but using it standalone shall suffice if you like `company` more than `popup.el`.
+
 ---
 
 ## Articles

--- a/accent.el
+++ b/accent.el
@@ -115,5 +115,28 @@ of available options to be displayed in the popup.")
               (insert (symbol-name opt)))))
       (message "No accented characters available"))))
 
+(declare-function company-begin-backend "company")
+
+;;;###autoload
+(defun accent-company (command &rest _ignored)
+  "Backend for `company' to complete accents.
+
+See `company-backends' for the description of COMMAND."
+  (interactive (list 'interactive))
+  (let* ((after? (eq accent-position 'after))
+         (char (if after? (char-after) (char-before)))
+         (curr (intern (string char)))
+         (diac (assoc curr (accent-lst))))
+    (cl-case command
+      (interactive (company-begin-backend 'my/company-accent))
+      (prefix (when diac
+                (string char)))
+      (candidates (mapcar (lambda (d) (if after?
+                                          (format "%s%s" (string (char-before)) d)
+                                        (format "%s" d)))
+                          (cadr diac)))
+      (post-completion (when after?
+                         (delete-char 1))))))
+
 (provide 'accent)
 ;;; accent.el ends here

--- a/accent.el
+++ b/accent.el
@@ -128,7 +128,7 @@ See `company-backends' for the description of COMMAND."
          (curr (intern (string char)))
          (diac (assoc curr (accent-lst))))
     (cl-case command
-      (interactive (company-begin-backend 'my/company-accent))
+      (interactive (company-begin-backend 'accent-company))
       (prefix (when diac
                 (string char)))
       (candidates (mapcar (lambda (d) (if after?


### PR DESCRIPTION
I've added a [company-mode](https://github.com/company-mode/company-mode) backend to enter accented characters.

It doesn't add `company-mode` as a dependency to the package, but will work if `company-mode` is installed.

Here's how it looks for me with the [company-box](https://github.com/sebastiencs/company-box) frontend with the cursor after "e" and `accent-position` set to `before`:

![image](https://github.com/eliascotto/accent/assets/21692287/9ff55dd8-99ac-4810-8824-b04e2e44ddb3)

And the cursor after "H" with `accent-position` set to `after`:
![image](https://github.com/eliascotto/accent/assets/21692287/5f7d729d-9c89-4897-adc3-88c9ee236d4f)

I couldn't find a way to display just one character in this case, but it works.
